### PR TITLE
Removes default parameter value before required parameter

### DIFF
--- a/src/GoogleDistanceMatrix.php
+++ b/src/GoogleDistanceMatrix.php
@@ -225,16 +225,16 @@ class GoogleDistanceMatrix
         ];
         $parameters = http_build_query($data);
         $url = self::URL.'?'.$parameters;
-        
+
         return $this->request('GET', $url);
     }
-    
+
     /**
      * @param string $type
      * @param string $url
      * @return GoogleDistanceMatrixResponse
      */
-    private function request($type = 'GET', $url) : GoogleDistanceMatrixResponse
+    private function request($type, $url) : GoogleDistanceMatrixResponse
     {
         $client = new Client();
         $response = $client->request($type, $url);


### PR DESCRIPTION
Removes the default value from parameter `$type` in method `GoogleDistanceMatrix::request()`.

https://www.php.net/manual/en/functions.arguments.php#functions.arguments.default

> Note that any optional arguments should be specified after any required arguments, otherwise they cannot be omitted from calls.

Since the method is `private` and is only used within this class once (with a parameter), we can safely remove the default value from this parameter.

This will fix a deprecation introduced in PHP8.0:

https://php.watch/versions/8.0/deprecate-required-param-after-optional

>  Deprecated: Optional parameter $type declared before required parameter $url is implicitly treated as a required parameter in [...]